### PR TITLE
Fix blank canvas issue when clicking on a template

### DIFF
--- a/src/pages/AiMlFlows.tsx
+++ b/src/pages/AiMlFlows.tsx
@@ -302,7 +302,7 @@ export default function AiMlFlows() {
                               </Button>
                             </Link>
                             <Button asChild size="sm" className="bg-gradient-primary opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                              <Link to="/builder">
+                              <Link to="/builder" state={{ template }}>
                                 <Play className="w-4 h-4" />
                               </Link>
                             </Button>
@@ -391,7 +391,7 @@ export default function AiMlFlows() {
                               <Share className="w-4 h-4" />
                             </Button>
                             <Button asChild size="sm" className="bg-gradient-primary hover:opacity-90">
-                              <Link to="/builder">
+                              <Link to="/builder" state={{ template }}>
                                 Use Template
                               </Link>
                             </Button>

--- a/src/pages/CommunicationFlows.tsx
+++ b/src/pages/CommunicationFlows.tsx
@@ -176,12 +176,12 @@ export default function CommunicationFlows() {
                 Browse templates for Email, Social Media, and other communication tasks
               </p>
             </div>
-            <Link to="/builder">
-              <Button className="bg-gradient-primary hover:opacity-90 glow-primary">
+            <Button asChild className="bg-gradient-primary hover:opacity-90 glow-primary">
+              <Link to="/builder">
                 <Plus className="w-4 h-4 mr-2" />
                 Create from Scratch
-              </Button>
-            </Link>
+              </Link>
+            </Button>
           </div>
 
           {/* Search and Filters */}
@@ -301,11 +301,11 @@ export default function CommunicationFlows() {
                                 <Eye className="w-4 h-4" />
                               </Button>
                             </Link>
-                            <Link to="/builder">
-                              <Button size="sm" className="bg-gradient-primary opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                            <Button asChild size="sm" className="bg-gradient-primary opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                              <Link to="/builder" state={{ template }}>
                                 <Play className="w-4 h-4" />
-                              </Button>
-                            </Link>
+                              </Link>
+                            </Button>
                           </div>
                         </div>
                       )}
@@ -390,11 +390,11 @@ export default function CommunicationFlows() {
                             >
                               <Share className="w-4 h-4" />
                             </Button>
-                            <Link to="/builder">
-                              <Button size="sm" className="bg-gradient-primary hover:opacity-90">
+                            <Button asChild size="sm" className="bg-gradient-primary hover:opacity-90">
+                              <Link to="/builder" state={{ template }}>
                                 Use Template
-                              </Button>
-                            </Link>
+                              </Link>
+                            </Button>
                           </div>
                         </div>
                       </div>

--- a/src/pages/DataFlows.tsx
+++ b/src/pages/DataFlows.tsx
@@ -176,12 +176,12 @@ export default function DataFlows() {
                 Browse templates for Data Processing and Analytics
               </p>
             </div>
-            <Link to="/builder">
-              <Button className="bg-gradient-primary hover:opacity-90 glow-primary">
+            <Button asChild className="bg-gradient-primary hover:opacity-90 glow-primary">
+              <Link to="/builder">
                 <Plus className="w-4 h-4 mr-2" />
                 Create from Scratch
-              </Button>
-            </Link>
+              </Link>
+            </Button>
           </div>
 
           {/* Search and Filters */}
@@ -301,11 +301,11 @@ export default function DataFlows() {
                                 <Eye className="w-4 h-4" />
                               </Button>
                             </Link>
-                            <Link to="/builder">
-                              <Button size="sm" className="bg-gradient-primary opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                            <Button asChild size="sm" className="bg-gradient-primary opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                              <Link to="/builder" state={{ template }}>
                                 <Play className="w-4 h-4" />
-                              </Button>
-                            </Link>
+                              </Link>
+                            </Button>
                           </div>
                         </div>
                       )}
@@ -390,11 +390,11 @@ export default function DataFlows() {
                             >
                               <Share className="w-4 h-4" />
                             </Button>
-                            <Link to="/builder">
-                              <Button size="sm" className="bg-gradient-primary hover:opacity-90">
+                            <Button asChild size="sm" className="bg-gradient-primary hover:opacity-90">
+                              <Link to="/builder" state={{ template }}>
                                 Use Template
-                              </Button>
-                            </Link>
+                              </Link>
+                            </Button>
                           </div>
                         </div>
                       </div>

--- a/src/pages/Flows.tsx
+++ b/src/pages/Flows.tsx
@@ -305,7 +305,7 @@ export default function Flows() {
                               </Button>
                             </Link>
                             <Button asChild size="sm" className="bg-gradient-primary opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                              <Link to="/builder">
+                              <Link to="/builder" state={{ template }}>
                                 <Play className="w-4 h-4" />
                               </Link>
                             </Button>
@@ -394,7 +394,7 @@ export default function Flows() {
                               <Share className="w-4 h-4" />
                             </Button>
                             <Button asChild size="sm" className="bg-gradient-primary hover:opacity-90">
-                              <Link to="/builder">
+                              <Link to="/builder" state={{ template }}>
                                 Use Template
                               </Link>
                             </Button>


### PR DESCRIPTION
This commit fixes an issue where the Workflow Builder would show a blank canvas when a template was clicked. The issue was that the template data was not being passed to the builder component. This has been fixed by passing the template data in the `state` prop of the `Link` component.