### PR TITLE
Fix CSS syntax error in global stylesheet

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -195,13 +195,3 @@
     }
   }
 }
-
-@layer base {
-  * {
-    @apply border-border;
-  }
-
-  body {
-    @apply bg-background text-foreground;
-  }
-}


### PR DESCRIPTION
This commit fixes a CSS syntax error in `src/index.css` where there were two `@layer base` blocks. This error was likely causing rendering issues across the entire application.